### PR TITLE
Fix: commitlintの導入

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,6 @@
 開発環境
 ```bash
 $ npm ci # Node.jsのバージョンは.node-versionを参照
-$ npx husky install # gitフックを有効にする
 $ npm run dev # 開発環境を起動(clientとserver両方)
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "heroku-postbuild": "npm run build",
     "start": "npm run start --workspace=server",
     "test:unit": "npm run test:unit --workspace=client",
-    "storybook": "npm run storybook --workspace=client"
+    "storybook": "npm run storybook --workspace=client",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",


### PR DESCRIPTION
npm scripts にはライフサイクルメソッドが存在するようで、
prepare に指定した処理がパッケージをインストールされたときなどに実行されるようです。
これで自分でコマンドを入力しなくてもパッケージをインストールした際に husky install が実行されます。

https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts